### PR TITLE
[사서 로테이션-사서 달력] 버그 픽스 및 간단한 함수 리팩토링

### DIFF
--- a/src/components/Rotation/Calendar.tsx
+++ b/src/components/Rotation/Calendar.tsx
@@ -12,9 +12,14 @@ import errorAlert from '@globalObj/function/errorAlert';
 import '@css/Rotation/Calendar.scss';
 import { getAuth } from '@cert/AuthStorage';
 
+const COLOR = {
+  me: '#e79f5a',
+  others: '#4992ce',
+};
+
 export default class Calendar extends React.Component {
-  intraId = getAuth() ? getAuth().id : null;
   state = {
+    auth: getAuth(),
     weekendsVisible: true,
     currentEvents: [],
   };
@@ -32,26 +37,44 @@ export default class Calendar extends React.Component {
             }}
             initialView="dayGridMonth"
             editable={true}
-            selectable={true}
-            selectMirror={true}
             dayMaxEvents={true}
             weekends={this.state.weekendsVisible}
             initialEvents={getRotationArr} // alternatively, use the `events` setting to fetch from a feed
-            select={this.handleDateSelect}
             eventContent={renderEventContent} // custom render function
             eventClick={this.handleEventClick}
+            dateClick={this.handleDateClick}
+            eventDrop={this.handleEventDrop}
             eventsSet={this.handleEvents} // called after events are initialized/added/changed/removed
-            /* you can update a remote database when these fire:
-            eventAdd={function(){}}
-            eventChange={function(){}}
-            eventRemove={function(){}}
-            */
-            eventDrop={handleDragAndDrop}
+            eventAdd={this.requestAdd}
+            eventRemove={this.requestRemove}
+            // eventChange={this.requestChange} // 드래그앤롭에서 revert() 해도 진행되어, 해당 훅을 활용하기 어려움을 확인
+
+            eventAllow={this.dropEventAllowHandler}
+
+            // 해당 기간외에 회색처리 되며 디스플레이도 되지 않음 => 하나의 달만을 가지고 핸들링시 활용도 존재.
+            // validRange = {{
+            //   start: '2023-02-01',
+            //   end: '2023-03-01'
+            // }}
           />
         </div>
       </div>
     );
   }
+
+  /*
+    동일 달 여부 => 기본적으로 같은 달안에서 이루어진다.
+    주말 여부 => 0인 일요일과 6인 토요일은 6으로 나누면 0
+    중복 여부(해당일자에 이미 사서 추가된 상태) => 날짜 & title(인트라id)를 비교
+    공휴일 여부 => 하고 싶다면 공휴일 정보는 미리 가져와서 추가 해야됨
+  */
+  dropEventAllowHandler = (dropInfo, draggedEvent) => {
+    const { currentEvents } = this.state;
+    const isSameMonth = draggedEvent.start.getMonth() === dropInfo.start.getMonth();
+    const isWeekend = dropInfo.start.getDay() % 6 === 0;
+    const isDuplicated = currentEvents.some((e) => e.startStr === dropInfo.startStr && e.title === draggedEvent.title);
+    return isSameMonth && !isWeekend && !isDuplicated;
+  };
 
   handleWeekendsToggle = () => {
     this.setState({
@@ -59,72 +82,142 @@ export default class Calendar extends React.Component {
     });
   };
 
-  handleDateSelect = (selectInfo) => {
-    let title = this.intraId;
-    if (title == null) {
-      alert('로그인을 먼저 해주세요!');
-      return;
-    }
-    let calendarApi = selectInfo.view.calendar;
-
-    calendarApi.unselect(); // clear date selection
-    if (title) {
-      axios
-        .patch(
-          `${getAddress()}/api/rotation/update`,
-          {
-            intraId: title,
-            before: '',
-            after: selectInfo.startStr,
-          },
-          {
-            headers: {
-              Authorization: 'Bearer ' + getToken(),
-            },
-          },
-        )
-        .catch((err) => errorAlert(err));
-      calendarApi.addEvent({
-        id: createEventId(),
-        title,
-        start: selectInfo.startStr,
-        end: selectInfo.endStr,
-        allDay: selectInfo.allDay,
-        color: '#e79f5a',
-      });
-    }
-  };
-
-  handleEventClick = (clickInfo) => {
-    let title = this.intraId;
-    if (title == null) {
-      alert('로그인을 먼저 해주세요!');
-      return;
-    }
-    if (title != clickInfo.event.title) {
-      alert('본인 일정만 삭제가 가능합니다.');
-      return;
-    }
-    if (confirm(`'${clickInfo.event.title}'를 삭제합니다`)) {
-      axios
-        .delete(`${getAddress()}/api/rotation/update`, {
-          headers: {
-            Authorization: 'Bearer ' + getToken(),
-          },
-          data: {
-            intraId: clickInfo.event.title,
-            date: clickInfo.event.startStr,
-          },
-        })
-        .catch((err) => errorAlert(err));
-      clickInfo.event.remove();
-    }
-  };
-
   handleEvents = (events) => {
     this.setState({
       currentEvents: events,
     });
+  };
+
+  handleDateClick = (info) => {
+    const isWeekend = info.date.getDay() % 6 === 0;
+    if (isWeekend) {
+      return;
+    }
+    
+    const { currentEvents, auth } = this.state;
+    const title = auth?.id;
+    
+    if (title === null) {
+      window.alert('로그인을 먼저 해주세요!');
+      return;
+    }
+
+    const isAlreadyIncluded = currentEvents.some((e) => e.title === title && e.startStr === info.dateStr);
+
+    if (isAlreadyIncluded) {
+      window.alert(`해당 날짜 '${info.dateStr}'에 본인의 일정이 이미 존재합니다.`);
+      return;
+    }
+
+    const calendarApi = info.view.calendar;
+
+    if (window.confirm(`'${info.dateStr}'에 일정을 추가합니다.`)) {
+      calendarApi.addEvent({
+        id: createEventId(),
+        title,
+        start: info.dateStr,
+        allDay: info.allDay,
+        color: COLOR.me,
+      });
+    }
+  };
+
+  handleEventDrop = (info) => {
+    const { auth } = this.state;
+    const title = auth?.id;
+
+    if (title === null) {
+      window.alert('로그인을 먼저 해주세요!');
+      info.revert();
+      return;
+    }
+
+    if (title !== info.event.title) {
+      window.alert('본인 일정만 변경이 가능합니다.');
+      info.revert();
+      return;
+    }
+
+    /* revert를 사용하더라도 eventChange 훅이 동작한다. 따라서 훅을 이용하지 않고 직접 this.requestChange 함수를 호출하여 사용한다. */
+    if (!window.confirm(`'${info.oldEvent.startStr}'을 '${info.event.startStr}'으로 일정을 변경합니다.`)) {
+      info.revert();
+      return;
+    }
+    this.requestChange(info);
+  };
+
+  handleEventClick = (clickInfo) => {
+    const { auth } = this.state;
+    const title = auth?.id;
+
+    if (title === null) {
+      window.alert('로그인을 먼저 해주세요!');
+      return;
+    }
+
+    const isOwner = title === clickInfo.event.title;
+
+    if (!isOwner) {
+      window.alert('본인 일정만 삭제가 가능합니다.');
+      return;
+    }
+
+    if (window.confirm(`'${clickInfo.event.startStr}' 일정을 삭제합니다`)) {
+      clickInfo.event.remove();
+    }
+  };
+
+  requestRotationUpdate = async (info, config, successMsg, errorMsg) => {
+    try {
+      const res = await axios(config);
+      window.alert(successMsg);
+    } catch (err) {
+      window.alert(errorMsg);
+      info.revert();
+      console.error(err);
+    }
+  };
+
+  requestAdd = async (info) => {
+    await this.requestRotationUpdate(
+      info,
+      {
+        method: 'patch',
+        url: `${getAddress()}/api/rotation/update`,
+        data: { intraId: info.event.title, before: '', after: info.event.startStr },
+        headers: { Authorization: `Bearer ${getToken()}` },
+      },
+      `사서 로테이션 일정<${info.event.startStr}>이 성공적으로 추가되었습니다.`,
+      `사서 로테이션 일정<${info.event.startStr}>추가에 실패했습니다.`,
+    );
+  };
+
+  requestRemove = async (info) => {
+    await this.requestRotationUpdate(
+      info,
+      {
+        method: 'delete',
+        url: `${getAddress()}/api/rotation/update`,
+        data: { intraId: info.event.title, date: info.event.startStr },
+        headers: { Authorization: `Bearer ${getToken()}` },
+      },
+      `사서 로테이션 일정<${info.event.startStr}>이 성공적으로 제거되었습니다.`,
+      `사서 로테이션 일정<${info.event.startStr}>제거에 실패했습니다.`,
+    );
+  };
+
+  requestChange = async (info) => {
+    await this.requestRotationUpdate(
+      info,
+      {
+        method: 'patch',
+        url: `${getAddress()}/api/rotation/update`,
+        data: { intraId: info.event.title, before: info.oldEvent.startStr, after: info.event.startStr },
+        headers: { Authorization: `Bearer ${getToken()}` },
+      },
+      `사서 로테이션 일정<${info.oldEvent.startStr}>이 <${info.event.startStr}>으로 성공적으로 변경되었습니다.`,
+      `사서 로테이션 일정<${info.oldEvent.startStr}>을 <${info.event.startStr}>로 변경에 실패했습니다.`,
+    );
   };
 }
 
@@ -135,40 +228,4 @@ function renderEventContent(eventInfo) {
       <i>{eventInfo.event.title}</i>
     </>
   );
-}
-
-function renderSidebarEvent(event) {
-  return (
-    <li key={event.id}>
-      <b>{formatDate(event.start, { year: 'numeric', month: 'short', day: 'numeric' })}</b>
-      <i>{event.title}</i>
-    </li>
-  );
-}
-
-function handleDragAndDrop(eventDropInfo) {
-  var intraId = getAuth() ? getAuth().id : null;
-  if (intraId == null) {
-    alert('로그인을 먼저 해주세요!');
-    return;
-  }
-  if (intraId != eventDropInfo.event.title) {
-    alert('본인 일정만 변경이 가능합니다.');
-    return;
-  }
-  axios
-    .patch(
-      `${getAddress()}/api/rotation/update`,
-      {
-        intraId: eventDropInfo.event.title,
-        before: eventDropInfo.oldEvent.startStr,
-        after: eventDropInfo.event.startStr,
-      },
-      {
-        headers: {
-          Authorization: 'Bearer ' + getToken(),
-        },
-      },
-    )
-    .catch((err) => errorAlert(err));
 }

--- a/src/components/Rotation/RotationResult.tsx
+++ b/src/components/Rotation/RotationResult.tsx
@@ -19,12 +19,11 @@ export const RotateResult = () => {
     setLoading(true); // api 호출 전에 true로 변경하여 로딩화면 띄우기
     try {
       const response = await getRotationMonthArr(month, year);
-      response.map((e) => {
-        if (e.title == intraId && e.start != '') {
-          arr.push(e.start);
-        }
-      });
-      arr.sort();
+      setArr(prev => [
+        ...prev,
+        ...response.filter(el => el.title == intraId && el.start != '')
+                  .map(el => el.start)
+      ].sort());
       setLoading(false); // api 호출 완료 됐을 때 false로 변경하려 로딩화면 숨김처리
     } catch (error) {
       window.alert(error);

--- a/src/components/Rotation/event_utils.tsx
+++ b/src/components/Rotation/event_utils.tsx
@@ -10,35 +10,19 @@ export function createEventId() {
 }
 
 function rotatedArrAllInfo(data) {
-  var intraId = getAuth() ? getAuth().id : null;
-  const rotatedArr = [];
-  let newdata = data.filter((e) => {
-    return e.attendDate !== undefined && e.attendDate !== null;
-  });
-  newdata.map((e) => {
-    e.attendDate = e.attendDate.split(',');
-  });
+  const intraId = getAuth() ? getAuth().id : null;
+  return data.filter(el => !!el.attendDate)
+    .map(el => el.attendDate.split(',')
+      .map(attendDate => ({
+        title: el.intraId,
+        start: attendDate,
+        color: intraId == el.intraId ? '#e79f5a' : '#4992ce'
+      }))).flat();
 
-  newdata.map((e) => {
-    e.attendDate.map((attendDate) => {
-      if (intraId == e.intraId) {
-        rotatedArr.push({ title: e.intraId, start: attendDate, color: '#e79f5a' });
-      } else {
-        rotatedArr.push({ title: e.intraId, start: attendDate, color: '#4992ce' });
-      }
-    });
-  });
-  return rotatedArr;
 }
 
 function rotatedArr(data) {
-  const rotatedArr = [];
-  data.map((e) => {
-    e.date.map((date) => {
-      rotatedArr.push({ title: e.intraId, start: date });
-    });
-  });
-  return rotatedArr;
+  return data.map(el => el.date.map(d => ({ title: el.intraId, start: d }))).flat();
 }
 
 export async function getRotationArr() {

--- a/src/components/Rotation/event_utils.tsx
+++ b/src/components/Rotation/event_utils.tsx
@@ -27,31 +27,24 @@ function rotatedArr(data) {
 
 export async function getRotationArr() {
   let rotationArr = [];
-  await axios
-    .get(`${getAddress()}/api/rotation`)
-    .then((res) => res.data)
-    .then((data) => {
-      const rotated = rotatedArrAllInfo(data);
-      rotationArr = rotated;
-    })
-    .catch((err) => console.log(err));
+  try {
+    const res = await axios.get(`${getAddress()}/api/rotation`);
+    const data = await res.data;
+    rotationArr = rotatedArrAllInfo(data);
+  } catch (error) {
+    console.log(error);
+  }
   return rotationArr;
 }
 
 export async function getRotationMonthArr(month, year) {
   let rotationArr = [];
-  await axios
-    .get(`${getAddress()}/api/rotation`, {
-      params: {
-        month: month,
-        year: year,
-      },
-    })
-    .then((res) => res.data)
-    .then((data) => {
-      const rotated = rotatedArr(data);
-      rotationArr = rotated;
-    })
-    .catch((err) => console.log(err));
-  return rotationArr;
+  try {
+    const res = await axios.get(`${getAddress()}/api/rotation`, {params: {month: month, year: year}});
+    const data = await res.data;
+    rotationArr = rotatedArr(data);
+  } catch (error) {
+    console.log(error);
+  }
+  return rotatedArr;
 }


### PR DESCRIPTION
yenawee님이 이전에 작성해주신 코드들은 기반으로 좀 더 올바른 동작들이 일어날 수 있도록 고도화만 진행하였습니다.
이번 PR에서는 주로 `사서 로테이션 탭`의 `사서 달력 메뉴`로 들어가면 나오는 http://localhost:3050/rotation/calendar 페이지의 기능만 수정하였습니다.

커밋에 어느정도 상세히 기재하였지만, 수정 된 사안에 대해서 나열하면

- 사서 일정은 `하루 단위 신청` & `시간대 고정`인 특성을 지님 => `allday=true`를 디폴트로 하고자함 && `select 기능 삭제 `&& `dateClick 기능 활용`
    - select는 여러날을 선택하여 start ~ end까지 설정하는 느낌인데
    - 하루단위의 사서 신청은 `allday=true && dateClick` 기능의 활용으로 대체 가능할것으로 판단
- `드래그앤 드롭`시 `드롭이 일어날 수 있는 영역을 제한`하는 `eventAllow`를 통해 바람직하지 않은 영역으로 드롭이벤트 발생하지 않도록 핸들링
- event 가 추가될때, 삭제될때 트리거되는 `eventAdd` && `eventRemove` 를 활용 (일종의 훅이라 불러도 될까?)
  - 해당 훅(?)들에 axios 요청하는 코드를 삽입
  - `axios 요청 실패시 revert()를 호출`하여 블록 추가 / 생성 / 수정 이벤트를 되돌림
  - `eventChange`는 드롭이벤트를 revert()하여도 트리거되어 사용하지 않고, handleEventDrop 함수 내에서 직접 axios 요청하도록 함
- `사서 신청 범위 제한`
  - 주말 X, 중복 사서 일정 등록 X, 로그인 필수, 같은 달(드래그앤 드랍 한정 by `eventAllow`)
  - `더 디테일한 핸들링`은 기능에 대한 `명확한 스펙`이 나와야 가능할것으로 판단 => `의견 부탁합니다~`