### PR TITLE
HOTFIX: 로테이션 참여 신청 막도록 임시 코드 추가

### DIFF
--- a/src/components/Rotation/Rotation.tsx
+++ b/src/components/Rotation/Rotation.tsx
@@ -28,6 +28,7 @@ export const Rotate = () => {
   const year = currentDate.getFullYear();
   const month = ((currentDate.getMonth() + 1) % 12) + 1;
   const intraId = getAuth() ? getAuth().id : null;
+  const isRotationApplicationPeriod = false;
   const [value, onChange] = useState(new Date());
   const [unavailableDates, setUnavailableDates] = useState([]);
   const [openSelectModal, setOpenSelectModal] = useState(false);
@@ -51,7 +52,8 @@ export const Rotate = () => {
   };
 
   const onClickPostEvent = () => {
-    if (getWeekNumber(currentDate) < 4 || currentDate > new Date(year, month - 1, -1)) {
+    // if (getWeekNumber(currentDate) < 4 || currentDate > new Date(year, month - 1, -1)) {
+    if (!isRotationApplicationPeriod) {
       alert('신청기간이 아닙니다!');
       return;
     }
@@ -78,6 +80,10 @@ export const Rotate = () => {
   };
 
   const onClickCancel = () => {
+    if (!isRotationApplicationPeriod) {
+      alert('신청기간이 아닙니다!');
+      return;
+    }
     axios
       .delete(`${getAddress()}/api/rotation/attend`, {
         headers: {
@@ -93,6 +99,15 @@ export const Rotate = () => {
       .catch((err) => errorAlert(err));
   };
 
+  if (!isRotationApplicationPeriod) {
+    return (
+      <div className="rotation--wrapper">
+        <div className="rotation--title">
+          현재 사서 로테이션 신청기간이 아닙니다.
+        </div>
+      </div>
+    );  
+  }
   return (
     <>
       <div className="rotation--wrapper">


### PR DESCRIPTION
사서 로테이션 기간이 아닌데, 로테이션 신청으로 인한 사이드 이펙트를 막기 위해 임시 코드를 첨부합니다.

임시로 로테이션 신청 기간인지 여부를 나타내는 불린형 변수 `isRotationApplicationPeriod` 에 false값 부여 후
HTML 코드와 axios 요청을 트리거 하는 코드에서 `isRotationApplicationPeriod`에 따라 동작하도록 하였습니다.

추후 `로테이션 신청 기간인지 여부를 판단하는 무언가`가 준비되면 적용할 예정입니다.

메시지는 아래와 같이 `현재 사서 로테이션 신청기간이 아닙니다.` 를 출력토록 했고, title에 잡힌 CSS가 이뻐서 그대로 사용했습니다.

<img width="779" alt="image" src="https://user-images.githubusercontent.com/36416495/221842197-51d3c6f7-43ea-4998-8753-209d55c3e39e.png">
