### PR TITLE
FEAT: 이벤트 참석 요청 페이지 생성 

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@ import Header from '@utils/Header';
 import Navbar from '@utils/Navbar';
 import MobileNavber from '@utils/MobileNavber';
 import DeviceMode, { getDeviceMode } from '@recoil/DeviceMode';
+import EventAttend from '@result/EventAttend';
 
 const Main = loadable(() => import('@main/index'));
 const Auth = loadable(() => import('@auth/index'));
@@ -37,6 +38,7 @@ const App = () => {
         <Route path="/" element={<Main />} />
         <Route path="/event/log" element={<EventLog />} />
         <Route path="/event/match" element={<Result />} />
+        <Route path="/event/attend/:eventId" element={<EventAttend />} />
         <Route path="/rotation/*" element={<Rotation />} />
         <Route path="/review/*" element={<Review />} />
         <Route path="/2022-timeline/" element={<Timeline />} />

--- a/src/components/Auth/AuthForm.tsx
+++ b/src/components/Auth/AuthForm.tsx
@@ -6,7 +6,7 @@ import ProfileChangeModalShow from '@recoil/ProfileChangeModalShow';
 import GlobalLoginState from '@recoil/GlobalLoginState';
 import axios from 'axios';
 import { saveToken } from '@cert/TokenStorage';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import SignUpProfileState from '@recoil/SignUpProfileState';
 import { saveAuth } from '@cert/AuthStorage';
 import getAddress from '@globalObj/function/getAddress';
@@ -27,7 +27,7 @@ function AuthForm(props: Props) {
   const setLoginState = useSetRecoilState(GlobalLoginState);
   const profileImageState = useRecoilValue(SignUpProfileState);
   const navigate = useNavigate();
-
+  const location = useLocation();
   const login = () => {
     axios
       .post(`${getAddress()}/api/auth/login`, {
@@ -47,7 +47,7 @@ function AuthForm(props: Props) {
           saveToken(res.data.token);
           saveAuth({ id, url: res.data.url });
           alert('로그인 되셨습니다');
-          navigate('/');
+          navigate(location.state?.from?.pathname || '/');
         } else {
           setErrorMessage('토큰 받아오기 실패');
         }

--- a/src/components/Result/EventAttend.tsx
+++ b/src/components/Result/EventAttend.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import '@css/Result/Result.scss';
+import axios from 'axios';
+import errorAlert from '@globalObj/function/errorAlert';
+import { getToken } from '@cert/TokenStorage';
+import getAddress from '@globalObj/function/getAddress';
+import { useNavigate, useParams } from 'react-router';
+
+function EventAttend() {
+  const navigate = useNavigate();
+  const { eventId } = useParams();
+
+  const requestRegister = async (eventId: string) => {
+    const url = `${getAddress()}/api/together/register`;
+    const data =  { eventId };
+    const config = { headers: { Authorization: 'Bearer ' + getToken() } };
+    try {
+      const resp = await axios.post(url, data, config);
+      const { attend } = resp.data;
+      console.log(attend);
+      alert('이벤트 참여에 신청되셨습니다');
+    } catch (error) {
+      errorAlert(error);
+    }
+    navigate("/");
+  }
+  useEffect(() => {
+    if (!getToken()) {
+      alert('로그인을 하셔야 신청 가능합니다!');
+      navigate("/auth", { state: { from: { pathname: `/event/attend/${eventId}` } } });
+      return;
+    }
+    requestRegister(eventId);
+  }, [])
+
+  return (
+    <></>
+  );
+}
+
+export default EventAttend;


### PR DESCRIPTION
# 업데이트 내용
- 친바의 이벤트 참석 유도를 위해서, 로그인 되어있다면 바로 이벤트 참석이 되는 url 제공하는것이 목적
- 이벤트 참석 페이지 생성
- 로그인 로직에 전달받은 pathname || "/" 로 리다이렉트 되도록 업데이트

# 이벤트 참석 페이지
- 이벤트 참석 요청만을 위한 페이지
- return (<></>);로 렌더링은 전혀 없음
- 비로그인 유저 => 로그인 페이지로 리다이렉트
  - navigate(url, { state: { from: { pathname: "someUrl" }}})로 필요한 데이터 전달
- 로그인 유저 => 바로 서버로 참석 요청 => 성공 및 실패 모두 안내 후, "/"로 리다이렉트
- `브라우저를 바로 닫아버리고 싶었는데..... 실패^^`

# 로그인 로직
- location = useLocation(); 전달 받은 데이터를 활용위함
- navigate(location.state?.from?.pathname || "/"); 로그인 성공 후, 리다이렉트