### PR TITLE
UPDATE: 사서로테이션 페이지 제출 내역 조회 & 선택한 날짜 캘린더에 CSS로 표현

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@ import Header from '@utils/Header';
 import Navbar from '@utils/Navbar';
 import MobileNavber from '@utils/MobileNavber';
 import DeviceMode, { getDeviceMode } from '@recoil/DeviceMode';
+import EventAttend from '@result/EventAttend';
 
 const Main = loadable(() => import('@main/index'));
 const Auth = loadable(() => import('@auth/index'));
@@ -37,6 +38,7 @@ const App = () => {
         <Route path="/" element={<Main />} />
         <Route path="/event/log" element={<EventLog />} />
         <Route path="/event/match" element={<Result />} />
+        <Route path="/event/attend/:eventId" element={<EventAttend />} />
         <Route path="/rotation/*" element={<Rotation />} />
         <Route path="/review/*" element={<Review />} />
         <Route path="/2022-timeline/" element={<Timeline />} />

--- a/src/assets/css/Rotation/New_Rotation.scss
+++ b/src/assets/css/Rotation/New_Rotation.scss
@@ -44,6 +44,7 @@
   padding: 5px;
   margin-bottom: 3px;
   border-radius: 4px;
+  span { margin: 0 2px; }
 }
 
 .rotation--reset {
@@ -117,5 +118,18 @@
   }
   &:active {
     background: #495057;
+  }
+}
+
+.react-calendar__viewContainer {
+  button.react-calendar__tile--active {
+    background: none !important;
+    color: rgb(0, 0, 0) !important;
+  }
+  button[disabled] { background: #f0f0f0 !important;}
+  button:not([disabled]) {
+    background: none !important;
+    &.selected, &.attendLimited { background: #01BABC !important; }
+    &:not(.selectable):hover { cursor: default !important;}
   }
 }

--- a/src/assets/css/Rotation/Rotation.scss
+++ b/src/assets/css/Rotation/Rotation.scss
@@ -9,9 +9,10 @@
 }
 
 .rotation--title {
-  margin-bottom: 30px;
+  text-align: center;
   font-size: 22px;
   font-family: 'Rowdies';
+
 }
 
 .rotation--selectUserTitle {
@@ -116,5 +117,6 @@
 .rotationCalendar--wrapper {
   @include mobile {
     @include basic--wrappers;
+    overflow-y: auto;
   }
 }

--- a/src/components/Auth/AuthForm.tsx
+++ b/src/components/Auth/AuthForm.tsx
@@ -6,7 +6,7 @@ import ProfileChangeModalShow from '@recoil/ProfileChangeModalShow';
 import GlobalLoginState from '@recoil/GlobalLoginState';
 import axios from 'axios';
 import { saveToken } from '@cert/TokenStorage';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import SignUpProfileState from '@recoil/SignUpProfileState';
 import { saveAuth } from '@cert/AuthStorage';
 import getAddress from '@globalObj/function/getAddress';
@@ -27,7 +27,7 @@ function AuthForm(props: Props) {
   const setLoginState = useSetRecoilState(GlobalLoginState);
   const profileImageState = useRecoilValue(SignUpProfileState);
   const navigate = useNavigate();
-
+  const location = useLocation();
   const login = () => {
     axios
       .post(`${getAddress()}/api/auth/login`, {
@@ -47,7 +47,7 @@ function AuthForm(props: Props) {
           saveToken(res.data.token);
           saveAuth({ id, url: res.data.url });
           alert('로그인 되셨습니다');
-          navigate('/');
+          navigate(location.state?.from?.pathname || '/');
         } else {
           setErrorMessage('토큰 받아오기 실패');
         }

--- a/src/components/Result/EventAttend.tsx
+++ b/src/components/Result/EventAttend.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import '@css/Result/Result.scss';
+import axios from 'axios';
+import errorAlert from '@globalObj/function/errorAlert';
+import { getToken } from '@cert/TokenStorage';
+import getAddress from '@globalObj/function/getAddress';
+import { useNavigate, useParams } from 'react-router';
+
+function EventAttend() {
+  const navigate = useNavigate();
+  const { eventId } = useParams();
+
+  const requestRegister = async (eventId: string) => {
+    const url = `${getAddress()}/api/together/register`;
+    const data =  { eventId };
+    const config = { headers: { Authorization: 'Bearer ' + getToken() } };
+    try {
+      const resp = await axios.post(url, data, config);
+      const { attend } = resp.data;
+      console.log(attend);
+      alert('이벤트 참여에 신청되셨습니다');
+    } catch (error) {
+      errorAlert(error);
+    }
+    navigate("/");
+  }
+  useEffect(() => {
+    if (!getToken()) {
+      alert('로그인을 하셔야 신청 가능합니다!');
+      navigate("/auth", { state: { from: { pathname: `/event/attend/${eventId}` } } });
+      return;
+    }
+    requestRegister(eventId);
+  }, [])
+
+  return (
+    <></>
+  );
+}
+
+export default EventAttend;


### PR DESCRIPTION
# 업데이트 내용
- 신청 기간 내, 로테이션 참여 여부를 서버에서 확인
- 신청 기간 내, 로테이션 참여 상태시 캘린더에 해당 정보를 출력, 하단 버튼은 취소 버튼으로
- 신청 기간 내, 로테이션 미참여 상태시 캘린더는 기존 처럼 활용, 하단 버튼은 신청 버튼으로

# 신청 기간 내, 로테이션 참여 상태시
<img width="561" alt="image" src="https://user-images.githubusercontent.com/36416495/231167593-c4dcf4a7-0408-42b7-af5a-746b859eac7b.png">

# 신청 기간 내, 로테이션 미참여 상태시
<img width="526" alt="image" src="https://user-images.githubusercontent.com/36416495/231167964-2a62d146-7e05-4051-8c34-9edcdc013d7d.png">

# P.S
- 저기 사용된 색상 #01BABC은 42 intra에 사용되는 메인 색상입니다.
- 하단의 버튼 색깔은 취소, 신청 버튼일때 다르게 하면 좋을텐데, 무슨 색깔로 할까 고민하다 데드락에 걸려서 이번엔 Pass

close #107 #109 