### PR TITLE
회원가입 페이지 및 로테이션 문구 수정

### DIFF
--- a/src/components/Auth/AuthSignUp.tsx
+++ b/src/components/Auth/AuthSignUp.tsx
@@ -20,6 +20,12 @@ const AuthSignUp = () => {
 
   const handleSubmit = (e: any) => {
     e.preventDefault();
+    const nickname = e.target[0].value;
+    const nicknameRegex = /^[a-zA-Z0-9-]+$/;
+    if (!nicknameRegex.test(nickname)) {
+      setNicknameError(true);
+      return;
+    }
     if (!e.target[0].value) {
       setNicknameError(true);
       return;
@@ -27,17 +33,17 @@ const AuthSignUp = () => {
     apiClient
       .post('/auth/signup', {
         nickname: e.target[0].value,
-        slackId: e.target[1].value,
+        slackId: '',
         imageUrl: profileImage,
       })
       .then((res) => {
         saveToken(res.data.access_token);
         setLoginState(() => {
           return {
-            id: res.data.id,
+            id: e.target[0].value,
             isLogin: true,
             isAdmin: false,
-            profileUrl: res.data.url,
+            profileUrl: profileImage,
           };
         });
         navigate('/');
@@ -61,9 +67,7 @@ const AuthSignUp = () => {
         {openProfileModal && <ProfileModal />}
         <form className={`authForm`} onSubmit={handleSubmit}>
           <input type="text" placeholder="닉네임을 입력해주세요" maxLength={10} className={`authForm--input`} />
-          {nicknameError && <p className={`authForm--error_message`}>닉네임을 입력해주세요.</p>}
-          <br />
-          <input type="text" placeholder="slack id" maxLength={20} className={`authForm--input`} />
+          {nicknameError && <p className={`authForm--error_message`}>닉네임은 영어대소문자, 숫자 그리고 '-'만 허용합니다.</p>}
           <br />
           <button className={`authForm--button`}>Sign Up</button>
         </form>

--- a/src/components/Rotation/Rotation.tsx
+++ b/src/components/Rotation/Rotation.tsx
@@ -240,9 +240,8 @@ const SelectDateNoticeBox = ({ isSubmit }: { isSubmit: boolean }) => (
       </>
     ) : (
       <>
-        <p>참여가 어려운 날짜를 선택해주세요 !</p>
+        <p>참여가 어려운 날짜를 선택해주세요!</p>
         <p>해당 날짜를 고려해서 랜덤 매칭이 이루어집니다</p>
-        <p>(필수 사항은 아닙니다)</p>
       </>
     )}
   </div>


### PR DESCRIPTION
회원가입 페이지에서 기존에 slackId를 입력하는 필드를 지우고 닉네임에 영어대소문자, 숫자 그리고 - 만 허용되게 하였습니다.